### PR TITLE
현재 블록 사용량 추적 및 시간 표시 기능 추가 / Add Current Block Usage Tracking with Time Display

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -49,6 +49,17 @@
       </div>
       
       <div class="usage-stats" id="usage-stats" style="display: none;">
+        <div class="stat-card blocks">
+          <div class="stat-header">
+            <span class="stat-label">Current Block (5h)</span>
+            <span class="block-time" id="blocks-time">-</span>
+          </div>
+          <div class="stat-value">
+            <span class="blocks-count" id="blocks-total">-</span>
+            <span class="cost" id="blocks-cost">$0.00</span>
+          </div>
+        </div>
+        
         <div class="stat-card today">
           <div class="stat-header">
             <span class="stat-label">Today</span>

--- a/src/main.ts
+++ b/src/main.ts
@@ -366,13 +366,14 @@ ipcMain.handle('get-usage-data', async () => {
     });
 
     // Get blocks data
-    const blocksArray = blocksData.blocks || [];
+    const blocksArray = Array.isArray(blocksData.blocks) ? blocksData.blocks : [];
     console.log('Blocks array:', blocksArray);
     
     // Find current active block
-    const currentBlock = blocksArray.find((block: any) => block.isActive === true);
+    const currentBlock = blocksArray.find((block: any) => 
+      block && typeof block === 'object' && block.isActive === true
+    );
     console.log('Current active block:', currentBlock);
-
     const result = {
       today: today ? {
         date: today.date,

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -74,14 +74,17 @@ const formatModels = (models: string[]): string => {
   }).join(', ');
 };
 
-const formatBlocks = (blocks: number): string => {
-  if (blocks >= 1000000) {
-    return (blocks / 1000000).toFixed(1) + 'M';
-  } else if (blocks >= 1000) {
-    return (blocks / 1000).toFixed(1) + 'k';
-  }
-  return blocks.toString();
-};
+-const formatBlocks = (blocks: number): string => {
+-  if (blocks >= 1000000) {
+-    return (blocks / 1000000).toFixed(1) + 'M';
+-  } else if (blocks >= 1000) {
+-    return (blocks / 1000).toFixed(1) + 'k';
+-  }
+-  return blocks.toString();
+-};
+
+-document.getElementById('blocks-total')!.textContent = formatBlocks(data.currentBlock.tokens);
++document.getElementById('blocks-total')!.textContent = formatNumber(data.currentBlock.tokens);
 
 const formatBlockTime = (startTime: string, endTime: string): string => {
   const start = new Date(startTime);

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -87,18 +87,27 @@ const formatModels = (models: string[]): string => {
 +document.getElementById('blocks-total')!.textContent = formatNumber(data.currentBlock.tokens);
 
 const formatBlockTime = (startTime: string, endTime: string): string => {
-  const start = new Date(startTime);
-  const end = new Date(endTime);
-  
-  const formatTime = (date: Date) => {
-    return date.toLocaleTimeString('en-US', { 
-      hour: '2-digit', 
-      minute: '2-digit', 
-      hour12: false 
-    });
-  };
-  
-  return `${formatTime(start)} - ${formatTime(end)}`;
+  try {
+    const start = new Date(startTime);
+    const end = new Date(endTime);
+    
+    if (isNaN(start.getTime()) || isNaN(end.getTime())) {
+      return 'Invalid time range';
+    }
+
+    const formatTime = (date: Date) => {
+      return date.toLocaleTimeString('en-US', { 
+        hour: '2-digit', 
+        minute: '2-digit', 
+        hour12: false 
+      });
+    };
+
+    return `${formatTime(start)} - ${formatTime(end)}`;
+  } catch (error) {
+    console.error('Error formatting block time:', error);
+    return 'Invalid time range';
+  }
 };
 
 const formatDateLabel = (dateString: string): string => {

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -74,17 +74,6 @@ const formatModels = (models: string[]): string => {
   }).join(', ');
 };
 
--const formatBlocks = (blocks: number): string => {
--  if (blocks >= 1000000) {
--    return (blocks / 1000000).toFixed(1) + 'M';
--  } else if (blocks >= 1000) {
--    return (blocks / 1000).toFixed(1) + 'k';
--  }
--  return blocks.toString();
--};
-
--document.getElementById('blocks-total')!.textContent = formatBlocks(data.currentBlock.tokens);
-+document.getElementById('blocks-total')!.textContent = formatNumber(data.currentBlock.tokens);
 
 const formatBlockTime = (startTime: string, endTime: string): string => {
   try {
@@ -173,7 +162,7 @@ async function loadUsageData() {
     
     // Update current block stats
     if (data.currentBlock) {
-      document.getElementById('blocks-total')!.textContent = formatBlocks(data.currentBlock.tokens);
+      document.getElementById('blocks-total')!.textContent = formatNumber(data.currentBlock.tokens);
       document.getElementById('blocks-cost')!.textContent = formatCost(data.currentBlock.cost);
       document.getElementById('blocks-time')!.textContent = formatBlockTime(data.currentBlock.startTime, data.currentBlock.endTime);
     } else {

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -15,6 +15,13 @@ interface Window {
           tokens: number;
           cost: number;
         };
+        currentBlock: {
+          tokens: number;
+          cost: number;
+          startTime: string;
+          endTime: string;
+          isActive: boolean;
+        } | null;
         recentSessions: Array<{
           name: string;
           tokens: number;
@@ -65,6 +72,30 @@ const formatModels = (models: string[]): string => {
     if (m.includes('haiku')) return 'Haiku';
     return m;
   }).join(', ');
+};
+
+const formatBlocks = (blocks: number): string => {
+  if (blocks >= 1000000) {
+    return (blocks / 1000000).toFixed(1) + 'M';
+  } else if (blocks >= 1000) {
+    return (blocks / 1000).toFixed(1) + 'k';
+  }
+  return blocks.toString();
+};
+
+const formatBlockTime = (startTime: string, endTime: string): string => {
+  const start = new Date(startTime);
+  const end = new Date(endTime);
+  
+  const formatTime = (date: Date) => {
+    return date.toLocaleTimeString('en-US', { 
+      hour: '2-digit', 
+      minute: '2-digit', 
+      hour12: false 
+    });
+  };
+  
+  return `${formatTime(start)} - ${formatTime(end)}`;
 };
 
 const formatDateLabel = (dateString: string): string => {
@@ -127,6 +158,17 @@ async function loadUsageData() {
     // Update total stats
     document.getElementById('total-tokens')!.textContent = formatNumber(data.total.tokens);
     document.getElementById('total-cost')!.textContent = formatCost(data.total.cost);
+    
+    // Update current block stats
+    if (data.currentBlock) {
+      document.getElementById('blocks-total')!.textContent = formatBlocks(data.currentBlock.tokens);
+      document.getElementById('blocks-cost')!.textContent = formatCost(data.currentBlock.cost);
+      document.getElementById('blocks-time')!.textContent = formatBlockTime(data.currentBlock.startTime, data.currentBlock.endTime);
+    } else {
+      document.getElementById('blocks-total')!.textContent = '0';
+      document.getElementById('blocks-cost')!.textContent = '$0.00';
+      document.getElementById('blocks-time')!.textContent = 'No active block';
+    }
     
     // Update recent sessions
     const sessionsList = document.getElementById('sessions-list')!;

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -137,6 +137,11 @@ body {
   color: #666;
 }
 
+.block-time {
+  font-size: 10px;
+  color: #666;
+}
+
 .stat-value {
   display: flex;
   justify-content: space-between;
@@ -156,6 +161,19 @@ body {
   margin-left: 4px;
 }
 
+.blocks-count {
+  font-size: 18px;
+  font-weight: 600;
+  color: #fff;
+}
+
+.blocks-count::after {
+  content: ' tokens';
+  font-size: 11px;
+  color: #666;
+  margin-left: 4px;
+}
+
 .cost {
   font-size: 16px;
   font-weight: 600;
@@ -168,6 +186,10 @@ body {
 
 .month .cost {
   color: #ffa54a;
+}
+
+.blocks .cost {
+  color: #9a4aff;
 }
 
 .recent-sessions {


### PR DESCRIPTION
# 현재 블록 사용량 추적 및 시간 표시 기능 추가 / Add Current Block Usage Tracking with Time Display

<img width="416" height="613" alt="Screenshot 2025-07-29 at 11 21 52 AM" src="https://github.com/user-attachments/assets/b5117fa9-7a76-4772-be28-9b144b703510" />

## 🇰🇷 한국어

### 📝 개요
ccusage blocks 명령어를 통합하여 현재 활성화된 5시간 블록의 사용량을 실시간으로 추적하고 표시하는 기능을 추가했습니다.

### ✨ 주요 기능
- **현재 블록 추적**: `ccusage blocks --json`을 통해 현재 활성 블록 정보 수집
- **토큰 사용량 표시**: 실제 입출력 토큰만 표시 (캐시 토큰 제외)
- **시간 범위 표시**: 블록의 시작-종료 시간을 24시간 형식으로 표시
- **UI 개선**: 현재 블록 카드를 최상단에 배치하여 가시성 향상
- **정확한 데이터**: `inputTokens + outputTokens`만 계산하여 실제 사용량 반영

### 🔧 기술적 변경사항
- **main.ts**: ccusage blocks 명령어 통합, 현재 활성 블록 검색 로직 추가
- **renderer.ts**: 블록 시간 포맷팅 함수 및 UI 업데이트 로직 추가
- **index.html**: 현재 블록 카드 UI 구조 변경 및 시간 표시 영역 추가
- **main.css**: 블록 관련 스타일링 및 시간 표시 스타일 추가

### 📊 표시 정보
```
Current Block (5h)
01:00 - 06:00
8.9k tokens    $0.73
```

### 🎯 사용자 경험 개선
- 현재 진행 중인 블록 정보를 즉시 확인 가능
- 블록의 정확한 시간 범위 제공
- 캐시 토큰 제외로 실제 사용량만 표시

---

## 🇺🇸 English

### 📝 Overview
Added functionality to track and display real-time usage of the currently active 5-hour block by integrating the ccusage blocks command.

### ✨ Key Features
- **Current Block Tracking**: Collect current active block information via `ccusage blocks --json`
- **Token Usage Display**: Show only actual input/output tokens (excluding cache tokens)
- **Time Range Display**: Show block start-end time in 24-hour format
- **UI Enhancement**: Position current block card at the top for better visibility
- **Accurate Data**: Calculate only `inputTokens + outputTokens` to reflect actual usage

### 🔧 Technical Changes
- **main.ts**: Integrated ccusage blocks command, added current active block search logic
- **renderer.ts**: Added block time formatting function and UI update logic
- **index.html**: Modified current block card UI structure and added time display area
- **main.css**: Added block-related styling and time display styles

### 📊 Display Information
```
Current Block (5h)
01:00 - 06:00
8.9k tokens    $0.73
```

### 🎯 User Experience Improvements
- Immediately view current active block information
- Provide exact time range of the block
- Show only actual usage by excluding cache tokens

### 📈 Files Changed
- 4 files changed, 108 insertions(+), 9 deletions(-)
- Enhanced type definitions and error handling
- Maintained existing functionality while adding new features

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Current Block (5h)" usage statistics card displaying active block token usage, cost, and time range.
* **Enhancements**
  * Improved usage data to include real-time block activity and statistics.
  * Updated formatting for block tokens and time ranges for clearer presentation.
* **Style**
  * Introduced new styles for block-related UI elements, including distinct typography and colors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->