### PR TITLE
🐛 fix: select most recent date when today's data is not available

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -325,9 +325,9 @@ ipcMain.handle('get-usage-data', async () => {
     // Find today's data or get the most recent day
     let today = dailyArray.find((d: any) => d.date === todayDate);
     
-    // If today's data is not found, get the most recent (first item in array)
+    // If today's data is not found, get the most recent (last item in array)
     if (!today && dailyArray.length > 0) {
-      today = dailyArray[0];
+      today = dailyArray[dailyArray.length - 1];
       console.log('Today not found, using most recent:', today.date);
     }
     


### PR DESCRIPTION
# Issue

#1 

# What

When today's usage data is not found in the available dates array, select the last item (most recent date) instead of the first item (oldest date). This ensures users see the most recent data available.