### PR TITLE
fix: extract full session_name from sessionId instead of just first segment

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -9,9 +9,9 @@ const execAsync = promisify(exec);
 function extractSessionNameFromId(sessionId: string): string {
   if (!sessionId) return 'session';
   
-  // Match pattern: -Users-${whoami}-workspace-${sessionType}-${sessionName}
-  // Extract the session name (the part after the second dash after workspace)
-  const match = sessionId.match(/-workspace-[^-]+-([^-]+)/);
+  // Match pattern: -Users-${whoami}-workspace-${sessionType}-${sessionName}  
+  // Extract the session name (everything after workspace-type-)
+  const match = sessionId.match(/-workspace-[^-]+-(.+)/);
   if (match && match[1]) {
     return match[1];
   }


### PR DESCRIPTION
## Summary

Fixed session name extraction to display the full session_name from sessionId instead of just the workspace type (temp/project).

## Changes
- Updated regex pattern in `extractSessionNameFromId` function
- Changed from `[^-]+` to `.+` to capture entire session name
- Now extracts full session names like "my_session_name" instead of just "temp"

## Test Plan
- Verify session names display correctly in UI
- Test with various sessionId formats

Fixes #2

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session name extraction to support names containing dashes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->