### PR TITLE
fix: move electron from devDependencies to dependencies for global install support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccusage-widget",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "A beautiful macOS desktop widget that displays your Claude Code usage statistics in real-time",
   "main": "dist/main.js",
   "bin": {


### PR DESCRIPTION
Fixes #25 where `npm install -g ccusage-widget` would fail with 'Cannot find module electron' because devDependencies are not installed during global installs.

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependency management to ensure Electron is included as a runtime dependency instead of a development-only dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->