### PR TITLE
feat: (GUI) Dynamic app metadata configuration from package.json

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,13 @@ import * as path from 'path';
 import { exec } from 'child_process';
 import { promisify } from 'util';
 
+const packageJson = require('../package.json');
 const execAsync = promisify(exec);
+
+// Set app name before app is ready (important for macOS)
+// Use productName from package.json if available, otherwise use name
+const appName = packageJson.build?.productName || packageJson.productName || packageJson.name || 'CCUsage Widget';
+app.setName(appName);
 
 // Helper function to extract session name from sessionId
 function extractSessionNameFromId(sessionId: string): string {
@@ -246,6 +252,17 @@ function updatePosition(position: WidgetConfig['position']) {
 }
 
 app.whenReady().then(() => {
+
+  // Set About panel options for macOS
+  app.setAboutPanelOptions({
+    applicationName: appName,
+    applicationVersion: packageJson.version,
+    version: packageJson.version,
+    copyright: 'Copyright © 2025 JeongJaeSoon',
+    authors: packageJson.author ? [packageJson.author.name || packageJson.author] : ['JeongJaeSoon'],
+    website: packageJson.homepage || 'https://github.com/JeongJaeSoon/ccusage-widget'
+  });
+
   createWindow();
   createTray();
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,8 +2,8 @@ import { app, BrowserWindow, ipcMain, screen, Menu, Tray, nativeImage } from 'el
 import * as path from 'path';
 import { exec } from 'child_process';
 import { promisify } from 'util';
+import packageJson from '../package.json';
 
-const packageJson = require('../package.json');
 const execAsync = promisify(exec);
 
 // Set app name before app is ready (important for macOS)

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,7 +8,7 @@ const execAsync = promisify(exec);
 
 // Set app name before app is ready (important for macOS)
 // Use productName from package.json if available, otherwise use name
-const appName = packageJson.build?.productName || packageJson.productName || packageJson.name || 'CCUsage Widget';
+const appName = packageJson.build?.productName || packageJson.name || 'CCUsage Widget';
 app.setName(appName);
 
 // Helper function to extract session name from sessionId
@@ -259,7 +259,9 @@ app.whenReady().then(() => {
     applicationVersion: packageJson.version,
     version: packageJson.version,
     copyright: 'Copyright © 2025 JeongJaeSoon',
-    authors: packageJson.author ? [packageJson.author.name || packageJson.author] : ['JeongJaeSoon'],
+    authors: packageJson.author ? 
+      [typeof packageJson.author === 'string' ? packageJson.author : packageJson.author.name || 'JeongJaeSoon'] : 
+      ['JeongJaeSoon'],
     website: packageJson.homepage || 'https://github.com/JeongJaeSoon/ccusage-widget'
   });
 


### PR DESCRIPTION
# Pull Request

## Description

This PR enhances the app's metadata management by dynamically loading configuration from `package.json`, providing better maintainability and consistency across the application. The app name, version, author, and other metadata are now centralized in one location.

### Key improvements:
- **Dynamic app name configuration**: The app now reads `productName` or `name` from package.json instead of hardcoding
- **macOS About dialog enhancement**: Properly displays version, author, and homepage information
- **Menu bar integration**: Sets the correct app name in macOS menu bar (shows "CCUsage Widget" instead of "Electron" in production builds)
- **Centralized metadata**: All app information is now managed from package.json

### Screenshots
The About dialog now properly displays version and app information from package.json, providing a professional appearance and making version management easier.
<img width="307" height="202" alt="Screenshot 2025-08-08 at 2 07 05" src="https://github.com/user-attachments/assets/3fc1d2d5-9d48-450d-ae93-d0632f0010a6" />
<img width="261" height="61" alt="Screenshot 2025-08-08 at 2 26 50" src="https://github.com/user-attachments/assets/654b6f57-cdea-40ea-98e5-968a91e6a1cd" />


## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Implementation Details

- Set app name dynamically from package.json (productName or name field)
- Add About panel options with version, author, and homepage from package.json
- Configure app name before app ready for proper macOS menu bar display
- Centralize all app metadata in package.json for easier maintenance

## Testing

- Verified that the app name displays correctly in macOS menu bar when running production build
- Confirmed About dialog shows correct version information
- Tested fallback behavior when fields are missing in package.json

## Related Issues

This improves the user experience by providing clear version information and proper app naming throughout the interface.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The application now displays metadata such as name, version, authors, and homepage in the macOS About panel, sourced directly from the app's configuration.
* **Enhancements**
  * The app name is set earlier during startup, improving consistency across the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->