### PR TITLE
feat: add CLI argument support with --version and --help flags

### DIFF
--- a/bin/ccusage-widget.js
+++ b/bin/ccusage-widget.js
@@ -3,7 +3,40 @@
 const { spawn } = require('child_process');
 const path = require('path');
 const fs = require('fs');
+const packageJson = require('../package.json');
 
+// Check command line arguments
+const args = process.argv.slice(2);
+
+if (args.length > 0) {
+  if (args.includes('--version') || args.includes('-v')) {
+    // Show version
+    console.log(packageJson.version);
+    process.exit(0);
+  } else if (args.includes('--help') || args.includes('-h')) {
+    // Show help
+    console.log(`
+CCUsage Widget v${packageJson.version}
+A beautiful macOS desktop widget for Claude Code usage statistics
+
+Usage: ccusage-widget [options]
+
+Options:
+  -v, --version  Show version number
+  -h, --help     Show this help message
+
+When run without options, launches the widget application.
+    `.trim());
+    process.exit(0);
+  } else {
+    // Unknown option
+    console.error(`Error: Unknown option '${args[0]}'`);
+    console.error('Try ccusage-widget --help for more information.');
+    process.exit(1);
+  }
+}
+
+// No arguments, proceed with normal execution
 const electronPath = require('electron');
 const appPath = path.join(__dirname, '..');
 


### PR DESCRIPTION
## Summary
- Added command-line argument parsing to support `--version`/`-v` and `--help`/`-h` flags
- Users can now check the widget version and get usage information directly from the terminal
- Improved CLI user experience with proper error handling for unknown options

## Type of change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Other

## Description
This PR enhances the CLI experience for ccusage-widget by adding standard command-line argument support. Users can now:

1. **Check version**: Run `ccusage-widget --version` or `ccusage-widget -v` to display the current version
2. **Get help**: Run `ccusage-widget --help` or `ccusage-widget -h` to see usage information
3. **Error handling**: Unknown options now display helpful error messages directing users to the help command

These changes allow users to interact with the widget's CLI without launching the Electron application when they just need version or usage information.

## Implementation Details
- Modified `bin/ccusage-widget.js` to parse command-line arguments before launching Electron
- Imported package.json to access version information dynamically
- Added graceful exit with appropriate exit codes (0 for success, 1 for errors)
- No breaking changes - running without arguments still launches the widget as expected

## Testing
- [x] Tested `--version` and `-v` flags display correct version
- [x] Tested `--help` and `-h` flags show usage information
- [x] Tested unknown options show error messages
- [x] Tested running without arguments launches the widget normally
- [x] All existing functionality remains intact

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.ai/code)