### PR TITLE
fix: Auto-update package.json version from git tag in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,9 @@ jobs:
         cache: 'npm'
         registry-url: 'https://registry.npmjs.org'
 
+    - name: Update package.json version
+      run: npm version ${{ github.ref_name }} --no-git-tag-version --allow-same-version
+
     - name: Install dependencies
       run: npm ci
 


### PR DESCRIPTION
## Summary
- Fixed version mismatch error in CI/CD pipeline by automatically updating package.json version to match git tag during release process
- Added npm version command to release workflow that syncs package.json version with the git tag version
- Prevents build failures caused by version discrepancies between git tags (e.g., v1.3.1) and package.json (e.g., 1.3.0)

## Changes
- Modified `.github/workflows/release.yml` to include automatic version update step before dependency installation
- Uses `npm version ${{ github.ref_name }} --no-git-tag-version --allow-same-version` to sync versions without creating additional git tags

## Test plan
- [ ] Verify release workflow runs successfully with version sync
- [ ] Confirm package.json version matches git tag version after release
- [ ] Test that subsequent build steps complete without version mismatch errors

🤖 Generated with [Claude Code](https://claude.ai/code)