### PR TITLE
fix: add npm authentication for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,9 @@ jobs:
         cache: 'npm'
         registry-url: 'https://registry.npmjs.org'
 
+    - name: Update package.json version
+      run: npm version ${{ github.ref_name }} --no-git-tag-version --allow-same-version
+
     - name: Install dependencies
       run: npm ci
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,6 +94,12 @@ jobs:
         fi
         echo "✅ All npm publish requirements met"
 
+    - name: Configure npm authentication
+      run: |
+        echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
+        echo "registry=https://registry.npmjs.org/" >> ~/.npmrc
+        echo "always-auth=true" >> ~/.npmrc
+
     - name: Publish to npm
       run: npm publish
       env:


### PR DESCRIPTION
## Summary
- Add explicit npm authentication configuration before publishing
- Fix npm ENEEDAUTH error during release process

## Changes
1. Add `.npmrc` configuration step before npm publish
2. Set authentication token, registry URL, and always-auth option explicitly

## Problem Solved
The release workflow was failing with:
```
npm error code ENEEDAUTH
npm error need auth This command requires you to be logged in to https://registry.npmjs.org/
```

## Solution
Created explicit npm authentication configuration by:
- Writing `.npmrc` file with auth token
- Setting registry URL to https://registry.npmjs.org/
- Enabling always-auth option

## Test Plan
- [ ] Verify NPM_TOKEN secret is set in repository settings
- [ ] Test release workflow with new tag
- [ ] Confirm npm publish succeeds with authentication

Co-authored-by: gemini-code-assist[bot] <176961590+gemini-code-assist[bot]@users.noreply.github.com>